### PR TITLE
removed mixin style for paper item in list wrapper to fix IE

### DIFF
--- a/etools-searchable-multiselection-menu.html
+++ b/etools-searchable-multiselection-menu.html
@@ -154,17 +154,15 @@ Custom property | Description | Default
       }
 
       .list-wrapper paper-item:not(.warning) {
-        --paper-item: {
-          padding: 0 16px;
-          cursor: pointer;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          box-sizing: border-box;
-          display: inline-block;
-          line-height: 48px;
-          width: 100%;
-        }
+        padding: 0 16px;
+        cursor: pointer;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        box-sizing: border-box;
+        display: inline-block;
+        line-height: 48px;
+        width: 100%;
       }
       .tick-icon {
         display: none;


### PR DESCRIPTION
This fixes problem in IE when a multiselect's options change dynamically and the new options do not get the paper-item styling applied. 