### PR TITLE
Adding possibility to edit paper-input-container-label styles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "etools-searchable-multiselection-menu",
   "description": "Dropdown menu with search and multiple options selection",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "license": "https://github.com/unicef-polymer/etools-searchable-multiselection-menu/blob/master/LICENSE.md",
   "main": "etools-searchable-multiselection-menu.html",
   "dependencies": {

--- a/etools-searchable-multiselection-menu.html
+++ b/etools-searchable-multiselection-menu.html
@@ -221,6 +221,12 @@ Custom property | Description | Default
           @apply(--esmm-readonly-input-container-label-focus);
         };
       }
+      
+      paper-input#singleSelectionDropdown {
+        --paper-input-container-label: {
+          @apply(--esmm-input-container-label);
+        };
+     }
 
     </style>
 


### PR DESCRIPTION
We need to possibility to edit inputs label styles in another module, so we are defining esmm-input-container-label mixin to achieve that.
(There's a --esmm-readonly-input-container-label mixin, but it applies only in readonly state and for label in search dropdown.)

