### PR TITLE
Fix dropdown resize

### DIFF
--- a/etools-searchable-multiselection-menu.html
+++ b/etools-searchable-multiselection-menu.html
@@ -572,6 +572,11 @@ Custom property | Description | Default
           if (emptyValue) {
             filtered.unshift({value: null, label: '-- None --', style: 'emptyValue'});
           }
+          
+          if (filtered && filtered.length) {
+            this.fire('resize');
+          }
+          
           return filtered;
         },
         _computeShowLimitWarning: function(limit, shownItems) {


### PR DESCRIPTION
There is a bug with dropdown resize. 
If we type something in search input, select item, then open dropdown again, dropdown won't resize on search input change. 

It can be fixed by using `resize` event.