### PR TITLE
Remove title attribute from paper-input

### DIFF
--- a/etools-searchable-multiselection-menu.html
+++ b/etools-searchable-multiselection-menu.html
@@ -241,7 +241,6 @@ Custom property | Description | Default
             on-focus="_openMenu"
             label="[[label]]"
             value="[[_getSingleSelectedOptionLabel(value)]]"
-            title="[[_getSingleSelectedOptionLabel(value)]]"
             disabled="[[disabled]]"
             error-message="[[errorMessage]]"
             required$="[[_simpleRequired(required)]]"

--- a/etools-searchable-multiselection-menu.html
+++ b/etools-searchable-multiselection-menu.html
@@ -241,6 +241,7 @@ Custom property | Description | Default
             on-focus="_openMenu"
             label="[[label]]"
             value="[[_getSingleSelectedOptionLabel(value)]]"
+            title="[[_getSingleSelectedInputTitle(value)]]"
             disabled="[[disabled]]"
             error-message="[[errorMessage]]"
             required$="[[_simpleRequired(required)]]"
@@ -514,6 +515,10 @@ Custom property | Description | Default
             type: Boolean,
             value: false
           },
+          noTitleAttr: {
+            type: Boolean,
+            value: false
+          },
           url: String,
           ajaxParams: Object
 
@@ -646,6 +651,10 @@ Custom property | Description | Default
             return value[this.optionLabel];
           }
           return null;
+        },
+        
+        _getSingleSelectedInputTitle: function(value) {
+          return this.noTitleAttr ? '' : this._getSingleSelectedOptionLabel(value);
         },
 
         _capitalizeInputValueClass: function() {


### PR DESCRIPTION
According to style guide we need to use custom tooltips.
This PR removes `title` attribute from input to prevent showing of browser native tooltip.