### PR TITLE
Add mixin for placeholder

### DIFF
--- a/deletable-option-list.html
+++ b/deletable-option-list.html
@@ -19,7 +19,7 @@
       }
 
       span.placeholder {
-        color: rgba(0, 0, 0, .38);
+        color: var(--esmm-placeholder-color, rgba(0, 0, 0, .38));
       }
 
       paper-icon-button {


### PR DESCRIPTION
We need a possibility to edit placeholder color when `multi` attribute is true. 
This PR adds a mixin for this and leaves previous color as default value.