### PR TITLE
Fix multi select not setting selected values when changed externally

### DIFF
--- a/etools-multi-selection-menu.html
+++ b/etools-multi-selection-menu.html
@@ -227,11 +227,11 @@ Dropdown with search and multi selection capabilities
         _hidePlaceholder: Boolean
       },
       observers: [
-        '_selectedValuesOrOptionsChanged(selectedValues, options)',
+        '_selectedValuesOrOptionsChanged(selectedValues, options, selectedValues.length)',
         '_notFoundOptionsAndUrlChanged(notFoundOptions, url)',
         '_selectedItemsChanged(selectedItems, selectedItems.length)'
       ],
-      _selectedValuesOrOptionsChanged: function(selectedValues, options) {
+      _selectedValuesOrOptionsChanged: function(selectedValues, options, selectedValuesLength) {
         this._selectedValuesToString();
         this._setSelectedItems(selectedValues);
 
@@ -418,6 +418,10 @@ Dropdown with search and multi selection capabilities
 
         return labels.join(' | ');
       },
+      clearValues: function() {
+        this.set('selectedValues', null);
+        this._selectedValuesOrOptionsChanged(null);
+      }
     });
   </script>
 </dom-module>

--- a/etools-multi-selection-menu.html
+++ b/etools-multi-selection-menu.html
@@ -227,11 +227,11 @@ Dropdown with search and multi selection capabilities
         _hidePlaceholder: Boolean
       },
       observers: [
-        '_selectedValuesOrOptionsChanged(selectedValues, options, selectedValues.length)',
+        '_selectedValuesOrOptionsChanged(selectedValues, options)',
         '_notFoundOptionsAndUrlChanged(notFoundOptions, url)',
         '_selectedItemsChanged(selectedItems, selectedItems.length)'
       ],
-      _selectedValuesOrOptionsChanged: function(selectedValues, options, selectedValuesLength) {
+      _selectedValuesOrOptionsChanged: function(selectedValues, options) {
         this._selectedValuesToString();
         this._setSelectedItems(selectedValues);
 


### PR DESCRIPTION
The observer looks for selected values to have a length otherwise it wont fire, so when the menu's selected items get cleared programmatically by a parent element the menu doesn't re-set the actual values.